### PR TITLE
Trim profile form fields before validation

### DIFF
--- a/src/modules/configuration/profile-update/actions/user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-profile-action.ts
@@ -17,7 +17,9 @@ export default async function profileAction(values: Record<string, any>) {
     return { error: 'Unauthorized' }
   }
   const filteredValues = Object.fromEntries(
-    Object.entries(values).filter(([, v]) => v !== '' && v !== undefined && v !== null)
+    Object.entries(values)
+      .map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
+      .filter(([, v]) => v !== '' && v !== undefined && v !== null)
   )
 
   const parsed = BackendProfileSchema.safeParse(filteredValues)


### PR DESCRIPTION
## Summary
- Trim profile form input values prior to validation to avoid erroneous "Invalid fields" responses.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689707404d0883278351c5a79eaa0e57