### PR TITLE
feat: move profile update button

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -195,6 +195,9 @@
     "result": "Result"
   },
   "SettingsPanel": {
+    "update": "Update",
+    "updated": "Updated",
+    "updateFailed": "Could not update",
     "language": {
       "english": "English",
       "spanish": "Spanish",

--- a/messages/es.json
+++ b/messages/es.json
@@ -195,6 +195,9 @@
     "result": "Resultado"
   },
   "SettingsPanel": {
+    "update": "Actualizar",
+    "updated": "Actualizado",
+    "updateFailed": "No se pudo actualizar",
     "language": {
       "english": "Inglés",
       "spanish": "Español",

--- a/src/app/[locale]/(features)/layout.tsx
+++ b/src/app/[locale]/(features)/layout.tsx
@@ -1,6 +1,7 @@
 // Layouts
 import Aside from '@/layouts/aside/layout/components/aside-layout'
 import Header from '@/layouts/header/layout/header-layout'
+import { SettingsFormProvider } from '@/modules/configuration/profile-update/contexts/settings-form-context'
 
 export default function FeaturesLayout({
   children
@@ -8,7 +9,7 @@ export default function FeaturesLayout({
   children: React.ReactNode
 }) {
   return (
-    <>
+    <SettingsFormProvider>
       {/* Header layout */}
       <Header />
       {/* Features pages */}
@@ -17,6 +18,6 @@ export default function FeaturesLayout({
       </main>
       {/* Aside layout  */}
       <Aside />
-    </>
+    </SettingsFormProvider>
   )
 }

--- a/src/layouts/aside/panels/components/options/settings-options.tsx
+++ b/src/layouts/aside/panels/components/options/settings-options.tsx
@@ -2,6 +2,7 @@
 
 // Buttons
 import OptionsButton from '@/modules/configuration/settings-panel/buttons/options-button'
+import UpdateButton from '@/modules/configuration/settings-panel/buttons/update-button'
 
 // Context
 import { useThemeContext } from '@/modules/configuration/settings-panel/hooks/useThemeContext'
@@ -48,6 +49,7 @@ const OptionsPanel: React.FC<OptionsPanelProps> = ({
       </div>
       {/* Selection buttons */}
       <div className='w-full h-fit flex flex-col'>
+        <UpdateButton />
         <OptionsButton
           icon={activeTheme === 'light' ? languageLightIcon : languageDarkIcon}
           label={languageLabel}

--- a/src/modules/configuration/profile-update/components/forms/profile-form.tsx
+++ b/src/modules/configuration/profile-update/components/forms/profile-form.tsx
@@ -1,12 +1,5 @@
 'use client'
 
-// Alerts
-import FormError from '@/modules/auth/form-pieces/alerts/error-alert'
-import FormSuccess from '@/modules/auth/form-pieces/alerts/success-alert'
-
-// Buttons
-import SubmitButton from '@/modules/configuration/profile-update/components/buttons/submit-button'
-
 // Cards
 import CardWrapper from '@/modules/configuration/profile-update/components/cards/card-wrapper'
 
@@ -18,7 +11,7 @@ import { FormProvider } from 'react-hook-form'
 
 
 // Hooks
-import { useSettingsForm } from '@/modules/configuration/profile-update/hooks/useSettingsForm'
+import { useSettingsFormContext } from '@/modules/configuration/profile-update/contexts/settings-form-context'
 
 // Inputs
 import AddressInput from '@/modules/configuration/profile-update/components/inputs/address-input'
@@ -47,18 +40,16 @@ import { Form } from '@/modules/ui/form'
 
 export default function SettingsForm() {
   // Hooks
-  const { form, error, success, isPending, hydrated, onSubmit } = useSettingsForm()
+  const { form, isPending, handleUpdate } = useSettingsFormContext()
 
   // Translations
   const f = useTranslations('ProfileForm')
-  const t = useTranslations('Button')
 
-
-  return hydrated ? (
+  return (
     <CardWrapper>
       <FormProvider {...form}>
         <Form {...form}>
-          <form className='space-y-8' onSubmit={form.handleSubmit(onSubmit)}>
+          <form className='space-y-8' onSubmit={handleUpdate}>
 
             <div className='space-y-8 mt-8'>
               <FormFieldset legend={f('identity')}>
@@ -90,18 +81,9 @@ export default function SettingsForm() {
               </FormFieldset>
             </div>
 
-            {/* Messages */}
-            <FormError message={error} />
-            <FormSuccess message={success} />
-
-            {/* Submit */}
-            <div className='w-full h-fit flex justify-end'>
-              <SubmitButton message={t('save')} isPending={isPending} />
-            </div>
-
           </form>
         </Form>
       </FormProvider>
     </CardWrapper>
-  ) : null
+  )
 }

--- a/src/modules/configuration/profile-update/contexts/settings-form-context.tsx
+++ b/src/modules/configuration/profile-update/contexts/settings-form-context.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
+
+import { useSettingsForm } from '@/modules/configuration/profile-update/hooks/useSettingsForm'
+import type { UseFormReturn } from 'react-hook-form'
+
+interface SettingsFormContextType {
+  form: UseFormReturn<any>
+  status: 'idle' | 'dirty' | 'success' | 'error'
+  isPending: boolean
+  handleUpdate: () => void
+}
+
+const SettingsFormContext = createContext<SettingsFormContextType | null>(null)
+
+export function SettingsFormProvider({ children }: { children: React.ReactNode }) {
+  const path = usePathname()
+  const isSettings = path?.includes('/settings')
+
+  const { form, error, success, isPending, hydrated, onSubmit } =
+    useSettingsForm(isSettings)
+
+  const [status, setStatus] = useState<'idle' | 'dirty' | 'success' | 'error'>('idle')
+
+  useEffect(() => {
+    if (!isSettings) return
+    const subscription = form.watch(() => {
+      setStatus(form.formState.isDirty ? 'dirty' : 'idle')
+    })
+    return () => subscription.unsubscribe()
+  }, [form, isSettings])
+
+  useEffect(() => {
+    if (!isSettings || !success) return
+    setStatus('success')
+    const timeout = setTimeout(() => setStatus('idle'), 3000)
+    return () => clearTimeout(timeout)
+  }, [success, isSettings])
+
+  useEffect(() => {
+    if (!isSettings || !error) return
+    setStatus('error')
+    const timeout = setTimeout(
+      () => setStatus(form.formState.isDirty ? 'dirty' : 'idle'),
+      3000
+    )
+    return () => clearTimeout(timeout)
+  }, [error, form, isSettings])
+
+  const handleUpdate = () => {
+    form.handleSubmit(onSubmit)()
+  }
+
+  if (!isSettings) return <>{children}</>
+
+  return (
+    <SettingsFormContext.Provider value={{ form, status, isPending, handleUpdate }}>
+      {hydrated ? children : null}
+    </SettingsFormContext.Provider>
+  )
+}
+
+export function useSettingsFormContext() {
+  const context = useContext(SettingsFormContext)
+  if (!context) {
+    throw new Error('useSettingsFormContext must be used within SettingsFormProvider')
+  }
+  return context
+}

--- a/src/modules/configuration/profile-update/hooks/useSettingsForm.tsx
+++ b/src/modules/configuration/profile-update/hooks/useSettingsForm.tsx
@@ -8,7 +8,7 @@ import { useForm } from 'react-hook-form'
 import profileAction from '@/modules/configuration/profile-update/actions/user-profile-action'
 import getUserProfileAction from '@/modules/configuration/profile-update/actions/get-user-profile-action'
 
-export function useSettingsForm() {
+export function useSettingsForm(enabled: boolean = true) {
   // States
   const [error, setError] = useState<string | undefined>('')
   const [hydrated, setHydrated] = useState(false)
@@ -45,14 +45,21 @@ export function useSettingsForm() {
     startTransition(() => {
       profileAction(values).then((data) => {
         if (data?.error) setError(data.error)
-        if (data?.success) setSuccess(data.success)
+        if (data?.success) {
+          setSuccess(data.success)
+          form.reset(values)
+        }
       })
     })
   }
 
   // Effects
   useEffect(() => {
-    (async () => {
+    if (!enabled) {
+      setHydrated(true)
+      return
+    }
+    ;(async () => {
       try {
         const data = await getUserProfileAction()
         if (data) form.reset(data)
@@ -62,6 +69,14 @@ export function useSettingsForm() {
         setHydrated(true)
       }
     })()
+  }, [form, enabled])
+
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      setError('')
+      setSuccess('')
+    })
+    return () => subscription.unsubscribe()
   }, [form])
 
   return {

--- a/src/modules/configuration/settings-panel/buttons/update-button.tsx
+++ b/src/modules/configuration/settings-panel/buttons/update-button.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Check } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { cn } from '@/lib/utils/classnames'
+import { useSettingsFormContext } from '@/modules/configuration/profile-update/contexts/settings-form-context'
+
+export default function UpdateButton() {
+  const { status, isPending, handleUpdate } = useSettingsFormContext()
+  const t = useTranslations('SettingsPanel')
+
+  let label = t('update')
+  if (status === 'success') label = t('updated')
+  if (status === 'error') label = t('updateFailed')
+
+  return (
+    <button
+      onClick={handleUpdate}
+      disabled={isPending}
+      className={cn(
+        'w-full text-sm text-left cursor-pointer px-8 py-4 flex justify-between items-center border-b-[0.05rem] border-[#EBEAEB] dark:border-[#3b3b40]',
+        'dark:hover:bg-[#26272C] hover:bg-[#F4F4F4]',
+        status === 'dirty' && 'animate-pulse dark:bg-[#26272C] bg-[#F4F4F4]'
+      )}
+    >
+      {label}
+      {status === 'success' && <Check className='w-5 h-5 text-green-600' />}
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- move profile update button to settings sidebar and animate on form changes
- share form state with sidebar via new context provider
- add translations for update button states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Dancing Script`)*

------
https://chatgpt.com/codex/tasks/task_e_6897109dc1ac8327a874f4142212f7cf