### PR TITLE
fix: handle profile form submission via context handler

### DIFF
--- a/src/modules/configuration/profile-update/components/forms/profile-form.tsx
+++ b/src/modules/configuration/profile-update/components/forms/profile-form.tsx
@@ -49,7 +49,7 @@ export default function SettingsForm() {
     <CardWrapper>
       <FormProvider {...form}>
         <Form {...form}>
-          <form className='space-y-8 text-sm' onSubmit={form.handleSubmit(onSubmit)}>
+          <form className='space-y-8 text-sm' onSubmit={handleUpdate}>
             <div className='space-y-8 mt-8'>
               <FormFieldset legend={f('identity')}>
                 <NameInput name='name' isPending={isPending} />

--- a/src/modules/configuration/profile-update/contexts/settings-form-context.tsx
+++ b/src/modules/configuration/profile-update/contexts/settings-form-context.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useEffect, useState } from 'react'
+import type { BaseSyntheticEvent } from 'react'
 import { usePathname } from 'next/navigation'
 
 import { useSettingsForm } from '@/modules/configuration/profile-update/hooks/useSettingsForm'
@@ -10,7 +11,7 @@ interface SettingsFormContextType {
   form: UseFormReturn<any>
   status: 'idle' | 'dirty' | 'success' | 'error'
   isPending: boolean
-  handleUpdate: () => void
+  handleUpdate: (event?: BaseSyntheticEvent) => void
 }
 
 const SettingsFormContext = createContext<SettingsFormContextType | null>(null)
@@ -49,8 +50,8 @@ export function SettingsFormProvider({ children }: { children: React.ReactNode }
     return () => clearTimeout(timeout)
   }, [error, form, isSettings])
 
-  const handleUpdate = () => {
-    form.handleSubmit(onSubmit)()
+  const handleUpdate = (event?: BaseSyntheticEvent) => {
+    form.handleSubmit(onSubmit)(event)
   }
 
   if (!isSettings) return <>{children}</>


### PR DESCRIPTION
## Summary
- use context handleUpdate to submit profile form
- allow SettingsFormContext.handleUpdate to receive events

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897151bf0088327a2c4c1be8c01ccd2