### PR TITLE
fix layout column ordering to keep aside on right

### DIFF
--- a/src/app/[locale]/(features)/layout.tsx
+++ b/src/app/[locale]/(features)/layout.tsx
@@ -13,7 +13,7 @@ export default function FeaturesLayout({
       {/* Header layout */}
       <Header />
       {/* Features pages */}
-      <main className='min-w-52 min-h-screen max-h-fit h-auto col-span-1'>
+      <main className='min-w-52 min-h-screen max-h-fit h-auto col-span-1 md:col-start-2'>
         {children}
       </main>
       {/* Aside layout  */}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -15,7 +15,7 @@ export default function StoriesPage() {
   return (
     <>
       <Header />
-      <main className='hidden md:flex min-w-[46rem] min-h-screen max-h-fit h-auto col-span-1 flex-col items-center gap-16'>
+      <main className='hidden md:flex md:col-start-2 min-w-[46rem] min-h-screen max-h-fit h-auto col-span-1 flex-col items-center gap-16'>
         <ShowPostStories />
         <ShowPostImages />
       </main>

--- a/src/layouts/aside/layout/components/aside-layout.tsx
+++ b/src/layouts/aside/layout/components/aside-layout.tsx
@@ -14,7 +14,7 @@ export default function Aside() {
   const component = usePageComponent() || null
   return (
     <aside
-      className={`hidden md:flex col-span-1 flex-col h-screen py-8 pr-8 sticky top-0 overflow-y-auto max-w-80 gap-8 ${styles.noScrollbar}`}
+      className={`hidden md:flex md:col-start-3 col-span-1 flex-col h-screen py-8 pr-8 sticky top-0 overflow-y-auto max-w-80 gap-8 ${styles.noScrollbar}`}
     >
       <Sidebar />
       {component && component}

--- a/src/layouts/header/layout/header-layout.tsx
+++ b/src/layouts/header/layout/header-layout.tsx
@@ -18,12 +18,12 @@ export default function Header() {
   const { searchContainerRef, isFocused } = useSearchContext()
 
   return !isFocused ? (
-    <header className='hidden md:flex col-span-1 border-r-[0.05rem] border-[#EBEAEB] dark:border-[#3b3b40] flex-col gap-8 min-h-screen max-h-fit h-auto py-8 sticky top-0 max-w-80'>
+    <header className='hidden md:flex md:col-start-1 col-span-1 border-r-[0.05rem] border-[#EBEAEB] dark:border-[#3b3b40] flex-col gap-8 min-h-screen max-h-fit h-auto py-8 sticky top-0 max-w-80'>
       <Logo />
       <ReturnSearchEngine />
     </header>
   ) : (
-    <header className='hidden md:flex col-span-1 border-r-[0.05rem] border-[#EBEAEB] dark:border-[#3b3b40] flex-col gap-8 min-h-screen max-h-fit h- sticky top-0 max-w-80'>
+    <header className='hidden md:flex md:col-start-1 col-span-1 border-r-[0.05rem] border-[#EBEAEB] dark:border-[#3b3b40] flex-col gap-8 min-h-screen max-h-fit h- sticky top-0 max-w-80'>
       <div className='w-full h-full flex' ref={searchContainerRef}>
         <div className='w-fit h-full border-r-[0.05rem] border-[#EBEAEB] dark:border-[#3b3b40] py-8 px-4'>
           <div className='w-fit h-fit mb-8 mx-auto'>


### PR DESCRIPTION
## Summary
- place header and aside in fixed grid columns
- ensure main content renders in center column

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971ad48308832792fa50a841482a71