### PR TITLE
feat: display update icon in profile settings

### DIFF
--- a/src/modules/configuration/settings-panel/buttons/update-button.tsx
+++ b/src/modules/configuration/settings-panel/buttons/update-button.tsx
@@ -31,15 +31,16 @@ export default function UpdateButton() {
       )}
     >
       {label}
-      {status === 'success' ? (
-        <Check className='w-5 h-5 text-green-600' />
-      ) : (
+      <span className='relative w-5 h-5'>
         <Image
           src={activeTheme === 'light' ? updateLightIcon : updateDarkIcon}
           alt='Update icon'
           className='w-5 h-5 aspect-square object-contain'
         />
-      )}
+        {status === 'success' && (
+          <Check className='absolute inset-0 w-5 h-5 text-green-600' />
+        )}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- always show Update icon in profile settings button, overlay checkmark on success

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971f55212483279b89f6fd25d4c76a