### PR TITLE
feat: enable navigation from search

### DIFF
--- a/src/modules/navigation/searcher/components/links/search-link.tsx
+++ b/src/modules/navigation/searcher/components/links/search-link.tsx
@@ -2,24 +2,33 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { useLocale } from 'next-intl'
+import { useSearchContext } from '@/modules/navigation/searcher/hooks/useSearchContext'
 
 interface SearchLinkProps {
-  // data: { id: string; title: string }[]
-  // locale: string
   iconSrc: string
-  // hrefBase: string
-  // altText: string
 }
 
 export default function SearchLink({ iconSrc }: SearchLinkProps) {
+  const { searchTerm, updateFocus, updateReset } = useSearchContext()
+  const locale = useLocale()
+  const term = searchTerm.trim()
+  const href = term ? `/${locale}/stories?search=${encodeURIComponent(term)}` : '#'
+
+  const handleClick = () => {
+    updateFocus(false)
+    updateReset(true)
+  }
+
   return (
     <li className='truncate w-full pr-4 pl-4 pt-1 pb-1 hover:bg-[#F4F4F4] dark:hover:bg-[#26272C] lowercase'>
       <Link
-        href=''
+        href={href}
         className='truncate flex gap-2 items-center dark:text-white'
+        onClick={handleClick}
       >
         <Image className='w-5' src={iconSrc} alt='Search' />
-        Data
+        {term || 'Data'}
       </Link>
     </li>
   )

--- a/src/modules/navigation/searcher/context/SearchContext.tsx
+++ b/src/modules/navigation/searcher/context/SearchContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useState, useEffect, useRef } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
 
 // 1. Creating the context
 const SearchContext = createContext<{
@@ -12,7 +13,7 @@ const SearchContext = createContext<{
   updateReset: (reset: boolean) => void
   updateSearch: (term: string) => void
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void
-  handleSubmit: (event: React.ChangeEvent<HTMLFormElement>) => void
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   isTyping: boolean // Añadido a la definición del contexto
 } | null>(null)
 
@@ -23,6 +24,10 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
   const [resetSearchInput, setResetSearchInput] = useState<boolean>(false)
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [isTyping, setIsTyping] = useState<boolean>(false)
+
+  // Router
+  const router = useRouter()
+  const pathname = usePathname()
 
   // Ref
   const searchContainerRef = useRef<HTMLDivElement>(null)
@@ -63,8 +68,14 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
     setSearchTerm('')
   }
 
-  const handleSubmit = (event: React.ChangeEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    const term = searchTerm.trim()
+    if (!term) return
+    const locale = pathname?.split('/')[1] || ''
+    router.push(`/${locale}/stories?search=${encodeURIComponent(term)}`)
+    setIsFocused(false)
+    setSearchTerm('')
   }
 
   // Effects


### PR DESCRIPTION
## Summary
- navigate to stories feed when submitting a search
- link search results to feed and reset search state

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971f93aa5483279fa9c5b80ea997af