### PR TITLE
feat: add live phone prefix search

### DIFF
--- a/src/modules/configuration/profile-update/actions/phone-prefix-action.ts
+++ b/src/modules/configuration/profile-update/actions/phone-prefix-action.ts
@@ -3,30 +3,32 @@
 // Prisma
 import { db } from '@/lib/orm/prisma-client'
 
-export async function getPhonePrefixes() {
-  
+/**
+ * Search phone prefixes matching the provided query.
+ * Removes duplicates and sorts the results numerically.
+ */
+export async function getPhonePrefixes(query: string) {
   try {
     const prefixes = await db.phonePrefix.findMany({
+      where: {
+        prefix: {
+          contains: query,
+          mode: 'insensitive'
+        }
+      },
       select: {
         prefix: true
-      }
+      },
+      distinct: ['prefix']
     })
-    // Remove duplicates and sort by prefix number
-    const uniquePrefixes = new Set(prefixes.map((p) => p.prefix))
-    /**
-     * Convert Set
-     * Sort by prefix number
-     */
-    return Array.from(uniquePrefixes).sort((a, b) => {
-      /**
-       * Remove non-numeric characters
-       * Convert to integer
-       * Compare prefix numbers
-       */
-      return (
-        parseInt(a.replace(/\D/g, ''), 10) - parseInt(b.replace(/\D/g, ''), 10)
+
+    return prefixes
+      .map((p) => p.prefix)
+      .sort(
+        (a, b) =>
+          parseInt(a.replace(/\D/g, ''), 10) -
+          parseInt(b.replace(/\D/g, ''), 10)
       )
-    })
   } catch (error) {
     console.error('Error fetching phone prefixes:', error)
     throw error

--- a/src/modules/configuration/profile-update/components/inputs/phone-prefix-input.tsx
+++ b/src/modules/configuration/profile-update/components/inputs/phone-prefix-input.tsx
@@ -31,7 +31,6 @@ interface PhonePrefixInputProps {
 
 const PhonePrefixInput = ({ name, isPending }: PhonePrefixInputProps) => {
   const t = useTranslations('Forms')
-  const [prefixes, setPrefixes] = useState<string[]>([])
   const [filteredPrefixes, setFilteredPrefixes] = useState<string[]>([])
   const [search, setSearch] = useState<string>('')
   const [hasSelected, setHasSelected] = useState<boolean>(false)
@@ -63,28 +62,27 @@ const PhonePrefixInput = ({ name, isPending }: PhonePrefixInputProps) => {
   }, [hydrated, session, fieldValue, name, setValue])
 
   useEffect(() => {
+    if (search.trim() === '' || hasSelected) {
+      setFilteredPrefixes([])
+      return
+    }
+
+    let isCancelled = false
+
     async function fetchPrefixes() {
       try {
-        const fetchedPrefixes = await getPhonePrefixes()
-        setPrefixes(fetchedPrefixes)
+        const fetchedPrefixes = await getPhonePrefixes(search)
+        if (!isCancelled) setFilteredPrefixes(fetchedPrefixes)
       } catch (error) {
         console.error('Error fetching phone prefixes:', error)
       }
     }
-    fetchPrefixes()
-  }, [])
 
-  useEffect(() => {
-    if (search.trim() === '' || hasSelected) setFilteredPrefixes([])
-    else {
-      const lowercasedSearch = search.toLowerCase()
-      setFilteredPrefixes(
-        prefixes.filter((prefix) =>
-          prefix.toLowerCase().includes(lowercasedSearch)
-        )
-      )
+    fetchPrefixes()
+    return () => {
+      isCancelled = true
     }
-  }, [search, prefixes, hasSelected])
+  }, [search, hasSelected])
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {


### PR DESCRIPTION
## Summary
- enable server-side phone prefix search
- fetch matching prefixes as the user types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68974a812e2483278ab4df00f69caee4